### PR TITLE
Registration response must use the received MID. Avoid fast libcoap a…

### DIFF
--- a/lib/services/coapRouter.js
+++ b/lib/services/coapRouter.js
@@ -127,7 +127,8 @@ function startCoap(config, callback) {
 
     serverInfo.server = libcoap.createServer({
         type: config.serverProtocol,
-        proxy: true
+        proxy: true,
+	piggybackReplyMs: 500
     });
 
     serverInfo.server.on('request', dataHandler(serverInfo));

--- a/lib/services/server/registration.js
+++ b/lib/services/server/registration.js
@@ -48,6 +48,7 @@ function endRegistration(req, res) {
 
             logger.debug(context, 'Registration request ended successfully');
             res.code = '2.01';
+            req._packet.messageId = res._packet.messageId;
             res.setOption('Location-Path', root + 'rd/' + result[1]);
             res.end('');
         }


### PR DESCRIPTION
…uto-reply.
